### PR TITLE
Version bump Scala/Lift

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,13 @@ organization := "com.stripe"
 
 scalaVersion := "2.9.2"
 
-crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.2")
+crossScalaVersions := Seq("2.9.1", "2.9.2")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpclient" % "[4.1, 4.2)",
-  "net.liftweb" %% "lift-json" % "2.5-RC1",
+  "net.liftweb" %% "lift-json" % "2.5-RC2",
   "org.scalatest" %% "scalatest" % "1.6.1" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ version := io.Source.fromFile("VERSION").mkString.trim
 
 organization := "com.stripe"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"
 
-crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1")
+crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.2")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpclient" % "[4.1, 4.2)",
-  "net.liftweb" %% "lift-json" % "2.4-M4",
+  "net.liftweb" %% "lift-json" % "2.5-RC1",
   "org.scalatest" %% "scalatest" % "1.6.1" % "test"
 )
 


### PR DESCRIPTION
This pull request version bumps the Lift JSON dependency, bumps the default compile version to 2.9.2, and drops support for older Scala versions no longer supported by Lift JSON.
