### PR TITLE
Add ability to change names on plans.

### DIFF
--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -266,6 +266,10 @@ case class Plan(
   currency: String,
   livemode: Boolean,
   trialPeriodDays: Option[Int]) extends APIResource {
+  def update(params: Map[String,_]): Plan = {
+    request("POST", instanceURL(this.id), params).extract[Plan]
+  }
+
   def delete(): DeletedPlan = {
     request("DELETE", instanceURL(this.id)).extract[DeletedPlan]
   }


### PR DESCRIPTION
The latest Stripe API spec allows for the names of plans to be updated. I've implemented that functionality in this Pull Request.
