### PR TITLE
Implement cards list and defaultCard attribute.

### DIFF
--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -159,6 +159,8 @@ abstract class APIResource {
 case class ErrorContainer(error: Error)
 case class Error(`type`: String, message: String, code: Option[String], param: Option[String])
 
+case class CardCollection(count: Int, data: List[Card])
+
 case class Card(
   last4: String,
   `type`: String,
@@ -217,7 +219,8 @@ case class Customer(
   id: String,
   livemode: Boolean,
   description: Option[String],
-  activeCard: Option[Card],
+  cards: CardCollection,
+  defaultCard: Option[String],
   email: Option[String],
   delinquent: Option[Boolean],
   subscription: Option[Subscription],

--- a/src/test/scala/com/stripe/StripeSuite.scala
+++ b/src/test/scala/com/stripe/StripeSuite.scala
@@ -84,7 +84,7 @@ class CustomerSuite extends FunSuite with StripeSuite {
   test("Customers can be created") {
     val customer = Customer.create(DefaultCustomerMap + ("description" -> "Test Description"))
     customer.description.get should be ("Test Description")
-    customer.activeCard.isEmpty should be (false)
+    customer.defaultCard.isEmpty should be (false)
   }
 
   test("Customers can be retrieved individually") {


### PR DESCRIPTION
This PR implements the cards list as a `CardCollection` and replaces the `activeCard` field with a `defaultCard` field that is a string to the default card. Breaks backward compatibility with API versions before 2013-07-05.
