### PR TITLE
Juggling Act: Various updates to stripe-scala.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,14 @@ version := io.Source.fromFile("VERSION").mkString.trim
 
 organization := "com.stripe"
 
-scalaVersion := "2.10.1"
-
-crossScalaVersions := Seq("2.9.1", "2.9.2")
+scalaVersion := "2.10.3"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpclient" % "[4.1, 4.2)",
-  "net.liftweb" %% "lift-json" % "2.5-RC2",
-  "org.scalatest" %% "scalatest" % "2.0.M5b" % "test"
+  "net.liftweb" %% "lift-json" % "2.5.1",
+  "org.scalatest" %% "scalatest" % "2.0.RC2" % "test"
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := io.Source.fromFile("VERSION").mkString.trim
 
 organization := "com.stripe"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.1"
 
 crossScalaVersions := Seq("2.9.1", "2.9.2")
 
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation")
 libraryDependencies ++= Seq(
   "org.apache.httpcomponents" % "httpclient" % "[4.1, 4.2)",
   "net.liftweb" %% "lift-json" % "2.5-RC2",
-  "org.scalatest" %% "scalatest" % "1.6.1" % "test"
+  "org.scalatest" %% "scalatest" % "2.0.M5b" % "test"
 )
 
 

--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -173,6 +173,7 @@ case class Error(`type`: String, message: String, code: Option[String], param: O
 case class CardCollection(count: Int, data: List[Card])
 
 case class Card(
+  id: String,
   last4: String,
   `type`: String,
   expMonth: Int,

--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -190,6 +190,19 @@ case class Card(
   addressLine1Check: Option[String] = None,
   addressZipCheck: Option[String] = None) extends APIResource
 
+case class Dispute(
+  livemode: Boolean,
+  amount: Int,
+  balanceTransaction: String,
+  charge: String,
+  created: Long,
+  currency: String,
+  reason: String,
+  status: String,
+  evidence: String,
+  evidenceDueBy: Long
+)
+
 case class Charge(
   created: Long,
   id: String,
@@ -198,15 +211,20 @@ case class Charge(
   amount: Int,
   currency: String,
   refunded: Boolean,
-  disputed: Boolean,
-  fee: Int,
   card: Card,
+  balanceTransaction: String,
+  dispute: Option[Dispute],
   failureMessage: Option[String],
   amountRefunded: Option[Int],
   customer: Option[String],
   invoice: Option[String],
   description: Option[String]) extends APIResource {
+
   def refund(): Charge = request("POST", "%s/refund".format(instanceURL(this.id))).extract[Charge]
+  def updateDispute(params: Map[String, _]): Dispute =
+    request("POST", s"${instanceURL(id)}/dispute", params).extract[Dispute]
+  def closeDispute(): Dispute =
+    request("POST", s"${instanceURL(id)}/dispute/close").extract[Dispute]
 }
 
 case class ChargeCollection(count: Int, data: List[Charge])

--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -27,14 +27,10 @@ case class CardException(msg: String, code: Option[String] = None, param: Option
 case class InvalidRequestException(msg: String, param: Option[String] = None) extends StripeException(msg)
 case class AuthenticationException(msg: String) extends StripeException(msg)
 
-object APIResource {
+abstract class APIResource {
   val ApiBase = "https://api.stripe.com/v1"
   val BindingsVersion = "1.1.2"
   val CharSet = "UTF-8"
-  val ApiVersion: Option[String] = None
-}
-abstract class APIResource {
-  import APIResource._
 
   //lift-json format initialization
   implicit val formats = json.DefaultFormats
@@ -83,7 +79,7 @@ abstract class APIResource {
         new BasicHeader("Authorization", "Bearer %s".format(apiKey))
       )
 
-      val apiVersionHeader = ApiVersion.map(new BasicHeader("Stripe-Version", _)).toList
+      val apiVersionHeader = apiVersion.map(new BasicHeader("Stripe-Version", _)).toList
 
       asJavaCollection(baseHeaders ++ apiVersionHeader)
     }

--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -393,12 +393,17 @@ object InvoiceItem extends APIResource {
 }
 
 case class InvoiceLineSubscriptionPeriod(start: Long, end: Long)
-case class InvoiceLineSubscription(plan: Plan, amount: Int, period: InvoiceLineSubscriptionPeriod)
-case class InvoiceLines(
-  subscriptions: List[InvoiceLineSubscription],
-  invoiceItems: List[InvoiceItem],
-  prorations: List[InvoiceItem]) extends APIResource {
-}
+case class InvoiceLine(
+  id: String,
+  livemode: Boolean,
+  amount: Long,
+  currency: String,
+  proration: Boolean,
+  period: InvoiceLineSubscriptionPeriod,
+  quantity: Option[Int],
+  plan: Option[Plan],
+  description: Option[String]) extends APIResource
+case class InvoiceLinesCollection(data: List[InvoiceLine], count: Int)
 
 case class Invoice(
   date: Long,
@@ -406,7 +411,7 @@ case class Invoice(
   id: Option[String],
   periodStart: Long,
   periodEnd: Long,
-  lines: InvoiceLines,
+  lines: InvoiceLinesCollection,
   subtotal: Int,
   total: Int,
   customer: String,

--- a/src/main/scala/com/stripe/Stripe.scala
+++ b/src/main/scala/com/stripe/Stripe.scala
@@ -226,6 +226,8 @@ object Charge extends APIResource {
 
 }
 
+case class SubscriptionCollection(count: Int, data: List[Subscription])
+
 case class Customer(
   created: Long,
   id: String,
@@ -235,7 +237,7 @@ case class Customer(
   defaultCard: Option[String],
   email: Option[String],
   delinquent: Option[Boolean],
-  subscription: Option[Subscription],
+  subscriptions: SubscriptionCollection,
   discount: Option[Discount],
   accountBalance: Option[Int]) extends APIResource {
   def update(params: Map[String,_]): Customer = {
@@ -246,12 +248,16 @@ case class Customer(
     request("DELETE", instanceURL(this.id)).extract[DeletedCustomer]
   }
 
-  def updateSubscription(params: Map[String,_]): Subscription = {
-    request("POST", "%s/subscription".format(instanceURL(id)), params).extract[Subscription]
+  def createSubscription(params: Map[String,_]): Subscription = {
+    request("POST", s"${instanceURL(id)}/subscriptions", params).extract[Subscription]
   }
 
-  def cancelSubscription(params: Map[String,_] = Map.empty): Subscription = {
-    request("DELETE", "%s/subscription".format(instanceURL(id)), params).extract[Subscription]
+  def updateSubscription(subscriptionId: String, params: Map[String, _]): Subscription = {
+    request("POST", s"${instanceURL(id)}/subscriptions/$subscriptionId", params).extract[Subscription]
+  }
+
+  def cancelSubscription(subscriptionId: String, params: Map[String,_] = Map.empty): Subscription = {
+    request("DELETE", s"${instanceURL(id)}/subscriptions/$subscriptionId", params).extract[Subscription]
   }
 }
 
@@ -309,6 +315,7 @@ object Plan extends APIResource {
 }
 
 case class Subscription(
+  id: String,
   plan: Plan,
   start: Long,
   status: String,

--- a/src/main/scala/com/stripe/package.scala
+++ b/src/main/scala/com/stripe/package.scala
@@ -4,5 +4,6 @@ import org.apache.http.conn.ClientConnectionManager
 
 package object stripe {
     var apiKey: String = ""
+    var apiVersion: Option[String] = None
     var connectionManager: ClientConnectionManager = null
 }

--- a/src/test/scala/com/stripe/StripeSuite.scala
+++ b/src/test/scala/com/stripe/StripeSuite.scala
@@ -306,7 +306,7 @@ class AccountSuite extends FunSuite with StripeSuite {
     account.chargeEnabled should equal (false)
     account.detailsSubmitted should be (false)
     account.statementDescriptor should be (None)
-    account.currenciesSupported.length should be (1)
-    account.currenciesSupported.head should be ("USD")
+    account.currenciesSupported.length should be (139)
+    account.currenciesSupported should contain ("usd")
   }
 }

--- a/src/test/scala/com/stripe/StripeSuite.scala
+++ b/src/test/scala/com/stripe/StripeSuite.scala
@@ -141,13 +141,13 @@ class PlanSuite extends FunSuite with StripeSuite {
   test("Customers can be created with a plan") {
     val plan = Plan.create(getUniquePlanMap)
     val customer = Customer.create(DefaultCustomerMap + ("plan" -> plan.id))
-    customer.subscription.get.plan.id should equal (plan.id)
+    customer.subscriptions.data.head.plan.id should equal (plan.id)
   }
 
   test("A plan can be added to a customer without a plan") {
     val customer = Customer.create(DefaultCustomerMap)
     val plan = Plan.create(getUniquePlanMap)
-    val subscription = customer.updateSubscription(Map("plan" -> plan.id))
+    val subscription = customer.createSubscription(Map("plan" -> plan.id))
     subscription.customer should equal (customer.id)
     subscription.plan.id should equal (plan.id)
   }
@@ -155,18 +155,22 @@ class PlanSuite extends FunSuite with StripeSuite {
   test("A customer's existing plan can be replaced") {
     val origPlan = Plan.create(getUniquePlanMap)
     val customer = Customer.create(DefaultCustomerMap + ("plan" -> origPlan.id))
-    customer.subscription.get.plan.id should equal (origPlan.id)
+    customer.subscriptions.data.head.plan.id should equal (origPlan.id)
+
+    val existingSubscriptionId = customer.subscriptions.data.head.id
     val newPlan = Plan.create(getUniquePlanMap)
-    val subscription = customer.updateSubscription(Map("plan" -> newPlan.id))
+    val subscription = customer.updateSubscription(existingSubscriptionId, Map("plan" -> newPlan.id))
     val updatedCustomer = Customer.retrieve(customer.id)
-    updatedCustomer.subscription.get.plan.id should equal (newPlan.id)
+    updatedCustomer.subscriptions.data.head.plan.id should equal (newPlan.id)
   }
 
   test("Customer subscriptions can be canceled") {
     val plan = Plan.create(getUniquePlanMap)
     val customer = Customer.create(DefaultCustomerMap + ("plan" -> plan.id))
-    customer.subscription.get.status should equal ("active")
-    val canceledSubscription = customer.cancelSubscription()
+    customer.subscriptions.data.head.status should equal ("active")
+    val existingSubscriptionId = customer.subscriptions.data.head.id
+
+    val canceledSubscription = customer.cancelSubscription(existingSubscriptionId)
     canceledSubscription.status should be ("canceled")
   }
 }

--- a/src/test/scala/com/stripe/StripeSuite.scala
+++ b/src/test/scala/com/stripe/StripeSuite.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 trait StripeSuite extends ShouldMatchers {
   //set the stripe API key
   apiKey = "tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I"
+  apiVersion = Some("2014-01-31")
 
   val DefaultCardMap = Map(
     "name" -> "Scala User",

--- a/src/test/scala/com/stripe/StripeSuite.scala
+++ b/src/test/scala/com/stripe/StripeSuite.scala
@@ -239,8 +239,9 @@ class InvoiceSuite extends FunSuite with StripeSuite {
     val invoices = Invoice.all(Map("customer" -> customer.id)).data
     val invoice = invoices.head
     invoice.customer should equal (customer.id)
-    val invoiceLineSubscription = invoice.lines.subscriptions.head
-    invoiceLineSubscription.plan.id should equal (plan.id)
+
+    val invoiceLinePlan = invoice.lines.data.head.plan.get
+    invoiceLinePlan.id should equal (plan.id)
   }
 
   test("Upcoming Invoices can be retrieved") {


### PR DESCRIPTION
This includes a handful of updates to stripe-scala that gets it in line with the API.

This gets specs passing with the 2014-01-31 API, including the following changes:
- Bump to 2.10 only so I could use string interpolation.
- Ability to explicitly specify `apiVersion`.
- Updates to Charge to support `dispute`.
- Updates to how invoice line items are presented so its in sync with the API.

Cheers!
